### PR TITLE
Make UI more compact

### DIFF
--- a/frontend/components/kanban/bulk-actions-toolbar.tsx
+++ b/frontend/components/kanban/bulk-actions-toolbar.tsx
@@ -43,7 +43,7 @@ export function BulkActionsToolbar() {
         'animate-in slide-in-from-bottom-2 duration-200'
       )}
     >
-      <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-3">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-3 px-3 py-2">
         <span className="text-sm text-muted-foreground">
           {count} task{count !== 1 ? 's' : ''} selected
         </span>

--- a/frontend/components/kanban/kanban-board.tsx
+++ b/frontend/components/kanban/kanban-board.tsx
@@ -217,7 +217,7 @@ function KanbanBoardInner({ repoFilter, searchQuery }: KanbanBoardProps) {
       </div>
 
       {/* Desktop layout - hidden on mobile */}
-      <div className="hidden h-full justify-center gap-4 overflow-x-auto p-4 lg:flex">
+      <div className="hidden h-full justify-center gap-3 overflow-x-auto p-3 lg:flex">
         {COLUMNS.map((status) => (
           <KanbanColumn
             key={status}
@@ -228,7 +228,7 @@ function KanbanBoardInner({ repoFilter, searchQuery }: KanbanBoardProps) {
       </div>
 
       {/* Mobile single column */}
-      <div className="flex-1 overflow-y-auto p-4 lg:hidden">
+      <div className="flex-1 overflow-y-auto p-3 lg:hidden">
         <KanbanColumn
           status={activeTab}
           tasks={tasks.filter((t) => t.status === activeTab)}
@@ -238,7 +238,7 @@ function KanbanBoardInner({ repoFilter, searchQuery }: KanbanBoardProps) {
 
       {/* Mobile drop zones - shown during drag */}
       {activeTask && (
-        <div className="fixed inset-x-0 bottom-0 flex gap-2 border-t bg-background/95 p-4 backdrop-blur-sm lg:hidden">
+        <div className="fixed inset-x-0 bottom-0 flex gap-2 border-t bg-background/95 p-3 backdrop-blur-sm lg:hidden">
           {COLUMNS.filter((s) => s !== activeTab).map((status) => (
             <MobileDropZone key={status} status={status} />
           ))}

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -11,7 +11,7 @@ function Card({
     <div
       data-slot="card"
       data-size={size}
-      className={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-lg py-4 text-xs/relaxed ring-1 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg group/card flex flex-col", className)}
+      className={cn("ring-foreground/10 bg-card text-card-foreground gap-3 overflow-hidden rounded-lg py-3 text-xs/relaxed ring-1 has-[>img:first-child]:pt-0 data-[size=sm]:gap-2 data-[size=sm]:py-2 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg group/card flex flex-col", className)}
       {...props}
     />
   )
@@ -22,7 +22,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "gap-1 rounded-t-lg px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
+        "gap-1 rounded-t-lg px-3 group-data-[size=sm]/card:px-2 [.border-b]:pb-3 group-data-[size=sm]/card:[.border-b]:pb-2 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
         className
       )}
       {...props}
@@ -67,7 +67,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      className={cn("px-3 group-data-[size=sm]/card:px-2", className)}
       {...props}
     />
   )
@@ -77,7 +77,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("rounded-b-lg px-4 group-data-[size=sm]/card:px-3 [.border-t]:pt-4 group-data-[size=sm]/card:[.border-t]:pt-3 flex items-center", className)}
+      className={cn("rounded-b-lg px-3 group-data-[size=sm]/card:px-2 [.border-t]:pt-3 group-data-[size=sm]/card:[.border-t]:pt-2 flex items-center", className)}
       {...props}
     />
   )

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -49,7 +49,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-3 rounded-xl p-3 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className
         )}
         {...props}

--- a/frontend/components/ui/field.tsx
+++ b/frontend/components/ui/field.tsx
@@ -9,7 +9,7 @@ function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
   return (
     <fieldset
       data-slot="field-set"
-      className={cn("gap-4 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3 flex flex-col", className)}
+      className={cn("gap-3 has-[>[data-slot=checkbox-group]]:gap-2 has-[>[data-slot=radio-group]]:gap-2 flex flex-col", className)}
       {...props}
     />
   )
@@ -35,7 +35,7 @@ function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="field-group"
       className={cn(
-        "gap-4 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4 group/field-group @container/field-group flex w-full flex-col",
+        "gap-3 data-[slot=checkbox-group]:gap-2 [&>[data-slot=field-group]]:gap-3 group/field-group @container/field-group flex w-full flex-col",
         className
       )}
       {...props}

--- a/frontend/routes/settings/index.tsx
+++ b/frontend/routes/settings/index.tsx
@@ -48,7 +48,7 @@ export const Route = createFileRoute('/settings/')({
 
 function SettingsSection({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="relative rounded-lg border border-border bg-card p-4 pt-6">
+    <div className="relative rounded-lg border border-border bg-card p-3 pt-5">
       <span className="absolute -top-2.5 left-3 rounded bg-card px-2 text-xs font-medium text-muted-foreground">
         {title}
       </span>
@@ -500,8 +500,8 @@ function SettingsPage() {
         <h1 className="text-sm font-medium">{t('title')}</h1>
       </div>
 
-      <div className="flex-1 overflow-auto p-6">
-        <div className="mx-auto max-w-5xl space-y-4">
+      <div className="flex-1 overflow-auto p-4">
+        <div className="mx-auto max-w-5xl space-y-3">
               {/* Server */}
               <SettingsSection title={t('sections.server')}>
                 <div className="space-y-1">
@@ -580,10 +580,10 @@ function SettingsPage() {
               </SettingsSection>
 
               {/* Editor + Integrations side by side */}
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 {/* Editor */}
                 <SettingsSection title={t('sections.editor')}>
-                  <div className="space-y-4">
+                  <div className="space-y-3">
                     {/* Editor App */}
                     <div className="space-y-1">
                       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -692,7 +692,7 @@ function SettingsPage() {
 
                 {/* Integrations */}
                 <SettingsSection title={t('sections.integrations')}>
-                  <div className="space-y-4">
+                  <div className="space-y-3">
                     {/* Linear API Key */}
                     <div className="space-y-1">
                       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -762,7 +762,7 @@ function SettingsPage() {
 
               {/* z.ai */}
               <SettingsSection title={t('sections.zai')}>
-                <div className="space-y-4">
+                <div className="space-y-3">
                   {/* Enable toggle */}
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                     <label className="text-sm text-muted-foreground sm:w-20 sm:shrink-0">
@@ -851,7 +851,7 @@ function SettingsPage() {
 
               {/* Notifications */}
               <SettingsSection title={t('sections.notifications')}>
-                <div className="space-y-4">
+                <div className="space-y-3">
                   {/* Master toggle */}
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                     <label className="text-sm text-muted-foreground sm:w-40 sm:shrink-0">
@@ -1085,7 +1085,7 @@ function SettingsPage() {
 
               {/* Appearance */}
               <SettingsSection title={t('sections.appearance')}>
-                <div className="space-y-4">
+                <div className="space-y-3">
                   {/* Language */}
                   <div className="space-y-1">
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-center">


### PR DESCRIPTION
## Summary
- Reduce spacing across the entire UI by ~4px per element for a tighter, more information-dense layout
- Changes apply to cards, dialogs, forms, kanban board, bulk actions toolbar, and settings page
- Maintains visual hierarchy while creating a more compact appearance

## Changes
| Component | Before | After |
|-----------|--------|-------|
| Card | py-4/gap-4 | py-3/gap-3 |
| Card (small) | py-3/gap-3 | py-2/gap-2 |
| Dialog | p-4/gap-4 | p-3/gap-3 |
| Field gaps | gap-4 | gap-3 |
| Kanban board | p-4/gap-4 | p-3/gap-3 |
| Bulk toolbar | gap-4/px-4/py-3 | gap-3/px-3/py-2 |
| Settings content | p-6, space-y-4 | p-4, space-y-3 |

## Test plan
- [ ] Verify kanban board layout looks correct on desktop and mobile
- [ ] Check dialogs (create task, delete confirmation, etc.) have proper spacing
- [ ] Review settings page sections for proper spacing
- [ ] Ensure cards in kanban columns look balanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)