### PR TITLE
Fix migration 0016 detection in test environment

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -123,6 +123,9 @@ function runMigrations(sqlite: Database, drizzleDb: BunSQLiteDatabase<typeof sch
       const hasEnvironmentVariables = sqlite
         .query("SELECT name FROM pragma_table_info('apps') WHERE name='environment_variables'")
         .get()
+      const hasNotificationsEnabled = sqlite
+        .query("SELECT name FROM pragma_table_info('apps') WHERE name='notifications_enabled'")
+        .get()
 
       // Determine which migrations should be marked as applied based on schema state
       const migrationsToMark: Array<{ tag: string; when: number }> = []
@@ -145,6 +148,10 @@ function runMigrations(sqlite: Database, drizzleDb: BunSQLiteDatabase<typeof sch
         }
         // 0015 adds environment_variables to apps
         else if (entry.tag.startsWith('0015') && hasEnvironmentVariables) {
+          shouldMark = true
+        }
+        // 0016 adds notifications_enabled to apps
+        else if (entry.tag.startsWith('0016') && hasNotificationsEnabled) {
           shouldMark = true
         }
 


### PR DESCRIPTION
## Summary
- Add landmark detection for the `notifications_enabled` column added in migration 0016
- Fixes CI test failures where migrations tried to add a column that already exists (from drizzle-kit push)

## Test plan
- [x] `bun test server/services/task-status.test.ts` passes
- [x] `bun test server/db/migrations.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)